### PR TITLE
Moved default data for webpages to CSV

### DIFF
--- a/Data/Lang/EN/webpages.csv
+++ b/Data/Lang/EN/webpages.csv
@@ -1,0 +1,4 @@
+creationdate;customcontroller;description;icon;idcluster;idpage;langcode;lastip;lastmod;noindex;ordernum;permalink;shorttitle;showonfooter;showonmenu;title;visitcount
+NULL;NULL;"Home description";"fa-file-o";NULL;"1";"en";NULL;NULL;"0";"100";"/";"Home";"0";"1";"Home";"0"
+NULL;NULL;"Cookies description";"fa-file-o";NULL;"2";"en";NULL;NULL;"1";"100";"/cookies";"Cookies";"1";"0";"Cookies";"0"
+NULL;NULL;"Privacy description";"fa-file-o";NULL;"3";"en";NULL;NULL;"1";"100";"/privacy";"Privacy";"1";"0";"Privacy";"0"

--- a/Data/Lang/ES/webpages.csv
+++ b/Data/Lang/ES/webpages.csv
@@ -1,0 +1,4 @@
+creationdate;customcontroller;description;icon;idcluster;idpage;langcode;lastip;lastmod;noindex;ordernum;permalink;shorttitle;showonfooter;showonmenu;title;visitcount
+NULL;NULL;"Home description";"fa-file-o";NULL;"1";"es";NULL;NULL;"0";"100";"/";"Home";"0";"1";"Home";"0"
+NULL;NULL;"Cookies description";"fa-file-o";NULL;"2";"es";NULL;NULL;"1";"100";"/cookies";"Cookies";"1";"0";"Cookies";"0"
+NULL;NULL;"Privacy description";"fa-file-o";NULL;"3";"es";NULL;NULL;"1";"100";"/privacy";"Privacy";"1";"0";"Privacy";"0"

--- a/Model/WebPage.php
+++ b/Model/WebPage.php
@@ -125,22 +125,6 @@ class WebPage extends WebPageClass
     }
 
     /**
-     * This function is called when creating the model table. Returns the SQL
-     * that will be executed after the creation of the table. Useful to insert values
-     * default.
-     *
-     * @return string
-     */
-    public function install()
-    {
-        return 'INSERT INTO ' . static::tableName() . " (title,shorttitle,description,"
-            . "permalink,langcode,showonmenu,showonfooter,noindex,icon) VALUES "
-            . "('Home','Home','Home description','/','" . substr(FS_LANG, 0, 2) . "',true,false,false,'fa-file-o'),"
-            . "('Cookies','Cookies','Cookies description','/cookies','" . substr(FS_LANG, 0, 2) . "',false,true,true,'fa-file-o'),"
-            . "('Privacy','Privacy','Privacy description','/privacy','" . substr(FS_LANG, 0, 2) . "',false,true,true,'fa-file-o');";
-    }
-
-    /**
      * Returns the name of the column that is the primary key of the model.
      *
      * @return string


### PR DESCRIPTION
- Added only EN and ES for now (Require add more default data for other languages)
- This way we can replace default data from other plugins that use webportal

**NOTE:** For now, require this manual steps:
- Activation of webportal
- Manual activation of plugin dependending of webportal
- Delete the table webpages
- When reload ListWebPages, the external data from secondary plugin can be used as default data.