### PR TITLE
Reduced query size to avoid MySQL fail create this table

### DIFF
--- a/Table/websearches.xml
+++ b/Table/websearches.xml
@@ -24,7 +24,7 @@
     </column>
     <column>
         <name>query</name>
-        <type>character varying(300)</type>
+        <type>character varying(100)</type>
         <null>NO</null>
     </column>
     <column>


### PR DESCRIPTION
Error message: Index column size too large. The maximum column size is 767 bytes.

**Note:** If needed can be increased until 254 characters