### PR TITLE
Fix param name for register contact

### DIFF
--- a/Controller/PortalRegisterMe.php
+++ b/Controller/PortalRegisterMe.php
@@ -96,8 +96,8 @@ class PortalRegisterMe extends PortalController
 
         $emailData = \explode('@', $email);
         $contact->nombre = empty($this->request->request->get('name')) ? $emailData[0] : $this->request->request->get('name');
-        $contact->apellidos = $this->request->request->get('apellidos', '');
-        $contact->descripcion = $this->request->request->get('descripcion', '');
+        $contact->apellidos = $this->request->request->get('surname', '');
+        $contact->descripcion = $this->request->request->get('description', $this->i18n->trans('my-address'));
         $contact->email = $email;
         $newPassword = $this->request->request->get('password', '');
         $newPassword2 = $this->request->request->get('password2', '');

--- a/Translation/en_EN.json
+++ b/Translation/en_EN.json
@@ -24,6 +24,7 @@
     "ipinfodb-credentials": "IPInfoDB credentials",
     "is-chatbot": "Is chatbot",
     "local-login": "Local login",
+    "my-address": "My Address",
     "new-contact-not-saved": "New contact not saved",
     "new-contact-saved": "New contact saved",
     "new-registrations-are-closed": "New registrations are closed at this time",

--- a/Translation/es_ES.json
+++ b/Translation/es_ES.json
@@ -24,6 +24,7 @@
     "ipinfodb-credentials": "IPInfoDB credentials",
     "is-chatbot": "Es chatbot",
     "local-login": "Login local",
+    "my-address": "Mi dirección",
     "new-contact-not-saved": "Nuevo contacto no registrado",
     "new-contact-saved": "Nuevo contacto registrado",
     "new-registrations-are-closed": "Nuevos registros están cerrados actualmente",


### PR DESCRIPTION
The description and surname parameters are updated to English so that they are in accordance with the rest of the parameters.
'My address' is set as the default value for records that do not indicate the description