### PR TITLE
Conver to lowecase the email on HybridLogin

### DIFF
--- a/Controller/HybridLogin.php
+++ b/Controller/HybridLogin.php
@@ -186,7 +186,7 @@ class HybridLogin extends PortalController
             return false;
         }
 
-        $email = $this->request->request->get('fsContact', '');
+        $email = \strtolower($this->request->request->get('fsContact', ''));
         if (empty($email) || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
             $this->miniLog->alert($this->i18n->trans('not-valid-email', ['%email%' => $email]));
             return false;


### PR DESCRIPTION
- Storage the email how lower case on the database.
- Pass the email to lower case on HybridLogin controller to get the same format.